### PR TITLE
database: Update database defaults and add country

### DIFF
--- a/database/3ds/get_friend_persistent_infos.go
+++ b/database/3ds/get_friend_persistent_infos.go
@@ -36,8 +36,6 @@ func GetFriendPersistentInfos(user1_pid uint32, pids []uint32) (*types.List[*fri
 		var msgUpdateTime uint64
 		var miiModifiedAtTime uint64
 
-		// * This is allowed to error for now.
-		// * Some of these fields are optional, and the DB doesn't have defaults
 		err := rows.Scan(
 			&pid,
 			&region,

--- a/database/3ds/get_friend_persistent_infos.go
+++ b/database/3ds/get_friend_persistent_infos.go
@@ -13,7 +13,7 @@ func GetFriendPersistentInfos(user1_pid uint32, pids []uint32) (*types.List[*fri
 	persistentInfos.Type = friends_3ds_types.NewFriendPersistentInfo()
 
 	rows, err := database.Postgres.Query(`
-	SELECT pid, region, area, language, favorite_title, favorite_title_version, comment, comment_changed, last_online, mii_changed FROM "3ds".user_data WHERE pid=ANY($1::int[])`, pq.Array(pids))
+	SELECT pid, region, area, language, country, favorite_title, favorite_title_version, comment, comment_changed, last_online, mii_changed FROM "3ds".user_data WHERE pid=ANY($1::int[])`, pq.Array(pids))
 	if err != nil {
 		return persistentInfos, err
 	}
@@ -28,6 +28,7 @@ func GetFriendPersistentInfos(user1_pid uint32, pids []uint32) (*types.List[*fri
 		var region uint8
 		var area uint8
 		var language uint8
+		var country uint8
 		var titleID uint64
 		var titleVersion uint16
 		var message string
@@ -37,11 +38,12 @@ func GetFriendPersistentInfos(user1_pid uint32, pids []uint32) (*types.List[*fri
 
 		// * This is allowed to error for now.
 		// * Some of these fields are optional, and the DB doesn't have defaults
-		rows.Scan(
+		err := rows.Scan(
 			&pid,
 			&region,
 			&area,
 			&language,
+			&country,
 			&titleID,
 			&titleVersion,
 			&message,
@@ -49,13 +51,16 @@ func GetFriendPersistentInfos(user1_pid uint32, pids []uint32) (*types.List[*fri
 			&lastOnlineTime,
 			&miiModifiedAtTime,
 		)
+		if err != nil {
+			return persistentInfos, err
+		}
 
 		gameKey.TitleID = types.NewPrimitiveU64(titleID)
 		gameKey.TitleVersion = types.NewPrimitiveU16(titleVersion)
 
 		persistentInfo.PID = types.NewPID(uint64(pid))
 		persistentInfo.Region = types.NewPrimitiveU8(region)
-		persistentInfo.Country = types.NewPrimitiveU8(0) // TODO - What is this?
+		persistentInfo.Country = types.NewPrimitiveU8(country)
 		persistentInfo.Area = types.NewPrimitiveU8(area)
 		persistentInfo.Language = types.NewPrimitiveU8(language)
 		persistentInfo.Platform = types.NewPrimitiveU8(2) // * Always 3DS

--- a/database/3ds/update_user_profile.go
+++ b/database/3ds/update_user_profile.go
@@ -8,13 +8,14 @@ import (
 // UpdateUserProfile updates a user's profile
 func UpdateUserProfile(pid uint32, profileData *friends_3ds_types.MyProfile) error {
 	_, err := database.Postgres.Exec(`
-		INSERT INTO "3ds".user_data (pid, region, area, language)
-		VALUES ($1, $2, $3, $4)
+		INSERT INTO "3ds".user_data (pid, region, area, language, country)
+		VALUES ($1, $2, $3, $4, $5)
 		ON CONFLICT (pid)
 		DO UPDATE SET 
 		region = $2,
 		area = $3,
-		language = $4`, pid, profileData.Region.Value, profileData.Area.Value, profileData.Language.Value)
+		language = $4,
+		country = $5`, pid, profileData.Region.Value, profileData.Area.Value, profileData.Language.Value, profileData.Country.Value)
 
 	if err != nil {
 		return err

--- a/database/init_postgres_3ds.go
+++ b/database/init_postgres_3ds.go
@@ -17,17 +17,18 @@ func initPostgres3DS() {
 		pid integer PRIMARY KEY,
 		show_online boolean DEFAULT true,
 		show_current_game boolean DEFAULT true,
-		comment text,
-		comment_changed bigint,
-		last_online bigint,
-		favorite_title bigint,
-		favorite_title_version integer,
-		mii_name text,
-		mii_data bytea,
-		mii_changed bigint,
-		region integer,
-		area integer,
-		language integer
+		comment text DEFAULT '',
+		comment_changed bigint DEFAULT 0,
+		last_online bigint DEFAULT 0,
+		favorite_title bigint DEFAULT 0,
+		favorite_title_version integer DEFAULT 0,
+		mii_name text DEFAULT '',
+		mii_data bytea DEFAULT '',
+		mii_changed bigint DEFAULT 0,
+		region integer DEFAULT 0,
+		area integer DEFAULT 0,
+		language integer DEFAULT 0,
+		country integer DEFAULT 0
 	)`)
 	if err != nil {
 		globals.Logger.Critical(err.Error())

--- a/database/init_postgres_wiiu.go
+++ b/database/init_postgres_wiiu.go
@@ -20,7 +20,7 @@ func initPostgresWiiU() {
 		block_friend_requests boolean DEFAULT false,
 		comment text DEFAULT '',
 		comment_changed bigint DEFAULT 0,
-		last_online bigint
+		last_online bigint DEFAULT 0
 	)`)
 	if err != nil {
 		globals.Logger.Critical(err.Error())


### PR DESCRIPTION
This prevents errors when scanning the fields on the database. Also add the country field to the 3DS database, which wasn't being tracked before for unknown reasons.

To migrate the existing database, the following queries have to be run:

<details>
<summary>Query</summary>

```
/* 3DS */
ALTER TABLE "3ds".user_data
ADD country integer DEFAULT 0,
ALTER COLUMN comment SET DEFAULT '',
ALTER COLUMN comment_changed SET DEFAULT 0,
ALTER COLUMN last_online SET DEFAULT 0,
ALTER COLUMN favorite_title SET DEFAULT 0,
ALTER COLUMN favorite_title_version SET DEFAULT 0,
ALTER COLUMN mii_name SET DEFAULT '',
ALTER COLUMN mii_data SET DEFAULT '',
ALTER COLUMN mii_changed SET DEFAULT 0,
ALTER COLUMN region SET DEFAULT 0,
ALTER COLUMN area SET DEFAULT 0,
ALTER COLUMN language SET DEFAULT 0;

UPDATE "3ds".user_data SET comment = '' WHERE comment IS NULL;
UPDATE "3ds".user_data SET comment_changed = 0 WHERE comment_changed IS NULL;
UPDATE "3ds".user_data SET last_online = 0 WHERE last_online IS NULL;
UPDATE "3ds".user_data SET favorite_title = 0 WHERE favorite_title IS NULL;
UPDATE "3ds".user_data SET favorite_title_version = 0 WHERE favorite_title_version IS NULL;
UPDATE "3ds".user_data SET mii_name = '' WHERE mii_name IS NULL;
UPDATE "3ds".user_data SET mii_data = '' WHERE mii_data IS NULL;
UPDATE "3ds".user_data SET mii_changed = 0 WHERE mii_changed IS NULL;
UPDATE "3ds".user_data SET region = 0 WHERE region IS NULL;
UPDATE "3ds".user_data SET area = 0 WHERE area IS NULL;
UPDATE "3ds".user_data SET language = 0 WHERE language IS NULL;

/* Wii U */
ALTER TABLE wiiu.user_data
ALTER COLUMN last_online SET DEFAULT 0;

UPDATE wiiu.user_data SET last_online = 0 WHERE last_online IS NULL;
```

</details>