### PR TITLE
fix(database): Proper checks on QueryRow for sql.ErrNoRows

### DIFF
--- a/database/3ds/update_user_last_online_time.go
+++ b/database/3ds/update_user_last_online_time.go
@@ -12,12 +12,12 @@ func UpdateUserLastOnlineTime(pid uint32, lastOnline *types.DateTime) error {
 	var showOnline bool
 
 	row, err := database.Manager.QueryRow(`SELECT show_online FROM "3ds".user_data WHERE pid=$1`, pid)
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil {
 		return err
 	}
 
 	err = row.Scan(&showOnline)
-	if err != nil {
+	if err != nil && err != sql.ErrNoRows {
 		return err
 	}
 

--- a/database/wiiu/accept_friend_request_and_return_friend_info.go
+++ b/database/wiiu/accept_friend_request_and_return_friend_info.go
@@ -16,16 +16,16 @@ func AcceptFriendRequestAndReturnFriendInfo(friendRequestID uint64) (*friends_wi
 
 	row, err := database.Manager.QueryRow(`SELECT sender_pid, recipient_pid FROM wiiu.friend_requests WHERE id=$1`, friendRequestID)
 	if err != nil {
+		return nil, err
+	}
+
+	err = row.Scan(&senderPID, &recipientPID)
+	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, database.ErrFriendRequestNotFound
 		} else {
 			return nil, err
 		}
-	}
-
-	err = row.Scan(&senderPID, &recipientPID)
-	if err != nil {
-		return nil, err
 	}
 
 	acceptedTime := types.NewDateTime(0).Now()
@@ -74,16 +74,16 @@ func AcceptFriendRequestAndReturnFriendInfo(friendRequestID uint64) (*friends_wi
 		var lastOnlineTime uint64
 		row, err = database.Manager.QueryRow(`SELECT last_online FROM wiiu.user_data WHERE pid=$1`, senderPID)
 		if err != nil {
+			return nil, err
+		}
+
+		err = row.Scan(&lastOnlineTime)
+		if err != nil {
 			if err == sql.ErrNoRows {
 				return nil, database.ErrPIDNotFound
 			} else {
 				return nil, err
 			}
-		}
-
-		err = row.Scan(&senderPID, &recipientPID)
-		if err != nil {
-			return nil, err
 		}
 
 		lastOnline = types.NewDateTime(lastOnlineTime) // TODO - Change this

--- a/database/wiiu/delete_friend_request_and_return_friend_pid.go
+++ b/database/wiiu/delete_friend_request_and_return_friend_pid.go
@@ -12,16 +12,16 @@ func DeleteFriendRequestAndReturnFriendPID(friendRequestID uint64) (uint32, erro
 
 	row, err := database.Manager.QueryRow(`SELECT recipient_pid FROM wiiu.friend_requests WHERE id=$1`, friendRequestID)
 	if err != nil {
+		return 0, err
+	}
+
+	err = row.Scan(&recipientPID)
+	if err != nil {
 		if err == sql.ErrNoRows {
 			return 0, database.ErrFriendRequestNotFound
 		} else {
 			return 0, err
 		}
-	}
-
-	err = row.Scan(&recipientPID)
-	if err != nil {
-		return 0, err
 	}
 
 	result, err := database.Manager.Exec(`

--- a/database/wiiu/get_pids_by_friend_request_id.go
+++ b/database/wiiu/get_pids_by_friend_request_id.go
@@ -13,16 +13,16 @@ func GetPIDsByFriendRequestID(friendRequestID uint64) (uint32, uint32, error) {
 
 	row, err := database.Manager.QueryRow(`SELECT sender_pid, recipient_pid FROM wiiu.friend_requests WHERE id=$1`, friendRequestID)
 	if err != nil {
+		return 0, 0, err
+	}
+
+	err = row.Scan(&senderPID, &recipientPID)
+	if err != nil {
 		if err == sql.ErrNoRows {
 			return 0, 0, database.ErrFriendRequestNotFound
 		} else {
 			return 0, 0, err
 		}
-	}
-
-	err = row.Scan(&senderPID, &recipientPID)
-	if err != nil {
-		return 0, 0, err
 	}
 
 	return senderPID, recipientPID, nil

--- a/database/wiiu/get_user_comment.go
+++ b/database/wiiu/get_user_comment.go
@@ -18,16 +18,16 @@ func GetUserComment(pid uint32) (*friends_wiiu_types.Comment, error) {
 
 	row, err := database.Manager.QueryRow(`SELECT comment, comment_changed FROM wiiu.user_data WHERE pid=$1`, pid)
 	if err != nil {
+		return nil, err
+	}
+
+	err = row.Scan(&contents, &changed)
+	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, database.ErrPIDNotFound
 		} else {
 			return nil, err
 		}
-	}
-
-	err = row.Scan(&contents, &changed)
-	if err != nil {
-		return nil, err
 	}
 
 	comment.Contents = types.NewString(contents)

--- a/database/wiiu/get_user_mii.go
+++ b/database/wiiu/get_user_mii.go
@@ -20,16 +20,16 @@ func GetUserMii(pid uint32) (*friends_wiiu_types.MiiV2, error) {
 
 	row, err := database.Manager.QueryRow(`SELECT name, unknown1, unknown2, data, unknown_datetime FROM wiiu.mii WHERE pid=$1`, pid)
 	if err != nil {
+		return nil, err
+	}
+
+	err = row.Scan(&name, &unknown1, &unknown2, &data, &datetime)
+	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, database.ErrPIDNotFound
 		} else {
 			return nil, err
 		}
-	}
-
-	err = row.Scan(&name, &unknown1, &unknown2, &data, &datetime)
-	if err != nil {
-		return nil, err
 	}
 
 	mii.Name = types.NewString(name)

--- a/database/wiiu/get_user_network_account_info.go
+++ b/database/wiiu/get_user_network_account_info.go
@@ -17,16 +17,16 @@ func GetUserNetworkAccountInfo(pid uint32) (*friends_wiiu_types.NNAInfo, error) 
 
 	row, err := database.Manager.QueryRow(`SELECT unknown1, unknown2 FROM wiiu.network_account_info WHERE pid=$1`, pid)
 	if err != nil {
+		return nil, err
+	}
+
+	err = row.Scan(&unknown1, &unknown2)
+	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, database.ErrPIDNotFound
 		} else {
 			return nil, err
 		}
-	}
-
-	err = row.Scan(&unknown1, &unknown2)
-	if err != nil {
-		return nil, err
 	}
 
 	nnaInfo.Unknown1 = types.NewPrimitiveU8(unknown1)

--- a/database/wiiu/get_user_principal_basic_info.go
+++ b/database/wiiu/get_user_principal_basic_info.go
@@ -17,16 +17,16 @@ func GetUserPrincipalBasicInfo(pid uint32) (*friends_wiiu_types.PrincipalBasicIn
 
 	row, err := database.Manager.QueryRow(`SELECT username, unknown FROM wiiu.principal_basic_info WHERE pid=$1`, pid)
 	if err != nil {
+		return nil, err
+	}
+
+	err = row.Scan(&nnid, &unknown)
+	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, database.ErrPIDNotFound
 		} else {
 			return nil, err
 		}
-	}
-
-	err = row.Scan(&nnid, &unknown)
-	if err != nil {
-		return nil, err
 	}
 
 	principalBasicInfo.PID = types.NewPID(uint64(pid))

--- a/database/wiiu/get_user_principal_preference.go
+++ b/database/wiiu/get_user_principal_preference.go
@@ -18,16 +18,16 @@ func GetUserPrincipalPreference(pid uint32) (*friends_wiiu_types.PrincipalPrefer
 
 	row, err := database.Manager.QueryRow(`SELECT show_online, show_current_game, block_friend_requests FROM wiiu.user_data WHERE pid=$1`, pid)
 	if err != nil {
+		return nil, err
+	}
+
+	err = row.Scan(&showOnlinePresence, &showCurrentTitle, &blockFriendRequests)
+	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, database.ErrPIDNotFound
 		} else {
 			return nil, err
 		}
-	}
-
-	err = row.Scan(&showOnlinePresence, &showCurrentTitle, &blockFriendRequests)
-	if err != nil {
-		return nil, err
 	}
 
 	preference.ShowOnlinePresence = types.NewPrimitiveBool(showOnlinePresence)

--- a/database/wiiu/save_friend_request.go
+++ b/database/wiiu/save_friend_request.go
@@ -17,12 +17,12 @@ func SaveFriendRequest(senderPID uint32, recipientPID uint32, sentTime uint64, e
 
 	// Make sure we don't already have that friend request! If we do, give them the one we already have.
 	row, err := database.Manager.QueryRow(`SELECT id FROM wiiu.friend_requests WHERE sender_pid=$1 AND recipient_pid=$2`, senderPID, recipientPID)
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil {
 		return 0, err
 	}
 
 	err = row.Scan(&id)
-	if err != nil {
+	if err != nil && err != sql.ErrNoRows {
 		return 0, err
 	} else if id != 0 {
 		// If they aren't blocked, we want to unset the denied status on the previous request we have so that it appears again.


### PR DESCRIPTION
With the transition to our sql-manager, the `QueryRow` functions had to be modified to make the `Scan` call later instead of inlined as it was previously. This affected all checks for `sql.ErrNoRows`, since this is returned by `Scan` and not `QueryRow`. Move the error check to `Scan` to fix the issues.