### PR TITLE
fix(3ds): Send friendship notification to proper target

### DIFF
--- a/nex/friends-3ds/add_friendship_by_pid.go
+++ b/nex/friends-3ds/add_friendship_by_pid.go
@@ -25,7 +25,7 @@ func AddFriendByPrincipalID(err error, packet nex.PacketInterface, callID uint32
 
 	connectedUser, ok := globals.ConnectedUsers.Get(pid.LegacyValue())
 	if ok && connectedUser != nil {
-		go notifications_3ds.SendFriendshipCompleted(connectedUser.Connection, pid.LegacyValue(), connection.PID())
+		go notifications_3ds.SendFriendshipCompleted(connectedUser.Connection, connection.PID())
 	}
 
 	rmcResponseStream := nex.NewByteStreamOut(globals.SecureEndpoint.LibraryVersions(), globals.SecureEndpoint.ByteStreamSettings())

--- a/nex/friends-3ds/sync_friend.go
+++ b/nex/friends-3ds/sync_friend.go
@@ -66,7 +66,7 @@ func SyncFriend(err error, packet nex.PacketInterface, callID uint32, lfc *types
 			// * Alert the other side, in case they weren't able to get our presence data
 			connectedUser, ok := globals.ConnectedUsers.Get(pid.LegacyValue())
 			if ok && connectedUser != nil {
-				go notifications_3ds.SendFriendshipCompleted(connectedUser.Connection, pid.LegacyValue(), connection.PID())
+				go notifications_3ds.SendFriendshipCompleted(connectedUser.Connection, connection.PID())
 			}
 		}
 

--- a/notifications/3ds/send_friendship_completed.go
+++ b/notifications/3ds/send_friendship_completed.go
@@ -9,15 +9,15 @@ import (
 	nintendo_notifications_types "github.com/PretendoNetwork/nex-protocols-go/v2/nintendo-notifications/types"
 )
 
-func SendFriendshipCompleted(connection *nex.PRUDPConnection, friendPID uint32, senderPID *types.PID) {
+func SendFriendshipCompleted(connection *nex.PRUDPConnection, senderPID *types.PID) {
 	notificationEvent := nintendo_notifications_types.NewNintendoNotificationEventGeneral()
 	notificationEvent.U32Param = types.NewPrimitiveU32(0)
-	notificationEvent.U64Param1 = types.NewPrimitiveU64(0)
-	notificationEvent.U64Param2 = types.NewPrimitiveU64(uint64(friendPID))
+	notificationEvent.U64Param1 = types.NewPrimitiveU64(0) // * Local friend code of sender
+	notificationEvent.U64Param2 = types.NewPrimitiveU64(types.NewDateTime(0).Now().Value()) // * Friendship timestamp
 
 	eventObject := nintendo_notifications_types.NewNintendoNotificationEvent()
 	eventObject.Type = types.NewPrimitiveU32(7)
-	eventObject.SenderPID = connection.PID()
+	eventObject.SenderPID = senderPID
 	eventObject.DataHolder = types.NewAnyDataHolder()
 	eventObject.DataHolder.TypeName = types.NewString("NintendoNotificationEventGeneral")
 	eventObject.DataHolder.ObjectData = notificationEvent.Copy()


### PR DESCRIPTION
The sender PID of the notification was being set to the target PID, instead of the sender PID. Use correct PID and remove redundant target PID argument.

Also fix minor accuracy issues.