### PR TITLE
fix(database/3ds): Fix INSERT query for UpdateUserMii

### DIFF
--- a/database/3ds/update_user_mii.go
+++ b/database/3ds/update_user_mii.go
@@ -9,8 +9,8 @@ import (
 // UpdateUserMii updates a user's mii
 func UpdateUserMii(pid uint32, mii *friends_3ds_types.Mii) error {
 	_, err := database.Manager.Exec(`
-		INSERT INTO "3ds".user_data (pid, mii_name, mii_data, mii_changed)
-		VALUES ($1, $2, $3, $4)
+		INSERT INTO "3ds".user_data (pid, mii_name, mii_profanity, mii_character_set, mii_data, mii_changed)
+		VALUES ($1, $2, $3, $4, $5, $6)
 		ON CONFLICT (pid)
 		DO UPDATE SET 
 		mii_name = $2,


### PR DESCRIPTION
Although the UPDATE section of the query was updated properly, the INSERT ection was unmodified, which causes type conflicts when trying to update the user's Mii. Update the INSERT query properly.