### PR TITLE
fix: Better initialization of NEX server accounts

### DIFF
--- a/globals/account_details_by_pid.go
+++ b/globals/account_details_by_pid.go
@@ -11,12 +11,12 @@ import (
 )
 
 func AccountDetailsByPID(pid *types.PID) (*nex.Account, *nex.Error) {
-	if pid.Equals(AuthenticationEndpoint.ServerAccount.PID) {
-		return AuthenticationEndpoint.ServerAccount, nil
+	if pid.Equals(AuthenticationServerAccount.PID) {
+		return AuthenticationServerAccount, nil
 	}
 
-	if pid.Equals(SecureEndpoint.ServerAccount.PID) {
-		return SecureEndpoint.ServerAccount, nil
+	if pid.Equals(SecureServerAccount.PID) {
+		return SecureServerAccount, nil
 	}
 
 	if pid.Equals(GuestAccount.PID) {

--- a/globals/globals.go
+++ b/globals/globals.go
@@ -10,6 +10,8 @@ import (
 )
 
 var Logger *plogger.Logger
+var AuthenticationServerAccount *nex.Account
+var SecureServerAccount *nex.Account
 var GuestAccount *nex.Account
 var KerberosPassword = "password" // * Default password
 var AuthenticationServer *nex.PRUDPServer

--- a/init.go
+++ b/init.go
@@ -13,6 +13,7 @@ import (
 	"github.com/PretendoNetwork/friends/types"
 	pb "github.com/PretendoNetwork/grpc-go/account"
 	"github.com/PretendoNetwork/nex-go/v2"
+	nex_types "github.com/PretendoNetwork/nex-go/v2/types"
 	"github.com/PretendoNetwork/plogger-go"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -66,10 +67,16 @@ func init() {
 		os.Exit(0)
 	}
 
+	globals.AuthenticationServerAccount = nex.NewAccount(nex_types.NewPID(1), "Quazal Authentication", authenticationServerPassword)
+
 	if strings.TrimSpace(secureServerPassword) == "" {
 		globals.Logger.Error("PN_FRIENDS_CONFIG_SECURE_PASSWORD environment variable not set")
 		os.Exit(0)
 	}
+
+	globals.SecureServerAccount = nex.NewAccount(nex_types.NewPID(2), "Quazal Rendez-Vous", secureServerPassword)
+
+	globals.GuestAccount = nex.NewAccount(nex_types.NewPID(100), "guest", "MMQea3n!fsik") // * Guest account password is always the same, known to all consoles
 
 	if strings.TrimSpace(aesKey) == "" {
 		globals.Logger.Error("PN_FRIENDS_CONFIG_AES_KEY environment variable not set")

--- a/nex/authentication.go
+++ b/nex/authentication.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/PretendoNetwork/friends/globals"
 	"github.com/PretendoNetwork/nex-go/v2"
-	"github.com/PretendoNetwork/nex-go/v2/types"
 )
 
 var serverBuildString string
@@ -17,9 +16,9 @@ func StartAuthenticationServer() {
 	globals.AuthenticationServer = nex.NewPRUDPServer()
 	globals.AuthenticationEndpoint = nex.NewPRUDPEndPoint(1)
 
+	globals.AuthenticationEndpoint.ServerAccount = globals.AuthenticationServerAccount
 	globals.AuthenticationEndpoint.AccountDetailsByPID = globals.AccountDetailsByPID
 	globals.AuthenticationEndpoint.AccountDetailsByUsername = globals.AccountDetailsByUsername
-	globals.AuthenticationEndpoint.ServerAccount = nex.NewAccount(types.NewPID(1), "Quazal Authentication", os.Getenv("PN_FRIENDS_CONFIG_AUTHENTICATION_PASSWORD"))
 
 	registerCommonAuthenticationServerProtocols()
 

--- a/nex/secure.go
+++ b/nex/secure.go
@@ -22,11 +22,9 @@ func StartSecureServer() {
 	globals.SecureServer = nex.NewPRUDPServer()
 	globals.SecureEndpoint = nex.NewPRUDPEndPoint(1)
 
+	globals.SecureEndpoint.ServerAccount = globals.SecureServerAccount
 	globals.SecureEndpoint.AccountDetailsByPID = globals.AccountDetailsByPID
 	globals.SecureEndpoint.AccountDetailsByUsername = globals.AccountDetailsByUsername
-	globals.SecureEndpoint.ServerAccount = nex.NewAccount(types.NewPID(2), "Quazal Rendez-Vous", os.Getenv("PN_FRIENDS_CONFIG_SECURE_PASSWORD"))
-
-	globals.GuestAccount = nex.NewAccount(types.NewPID(100), "guest", "MMQea3n!fsik") // * Guest account password is always the same, known to all consoles
 
 	globals.SecureEndpoint.OnConnectionEnded(func(connection *nex.PRUDPConnection) {
 		pid := connection.PID().LegacyValue()


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #XXX

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

Initializing the server accounts in their own thread (e.g. the authentication and secure servers) can cause a race condition where the secure account hasn't been set up yet when authentication configures `ticket-granting`, causing sometimes crashes on startup.

This has happened on production causing unnecesary restarts. To fix this, initialize the accounts on the `init` function to ensure they will always be accessible when needed.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.